### PR TITLE
Add IDbCommandLogFormatter to SentryCommandInterceptor

### DIFF
--- a/src/Sentry.EntityFramework/DbCommandLogFormatter.cs
+++ b/src/Sentry.EntityFramework/DbCommandLogFormatter.cs
@@ -1,0 +1,17 @@
+﻿using System.Data.Common;
+
+namespace Sentry.EntityFramework
+{
+    /// <summary>
+    /// Default implementation of <see cref="IDbCommandLogFormatter"/>
+    /// returns CommandText to log
+    /// </summary>
+    internal class DbCommandLogFormatter : IDbCommandLogFormatter
+    {
+        public string GetLogMessage(DbCommand command)
+        {
+            return command.CommandText;
+        }
+    }
+
+}

--- a/src/Sentry.EntityFramework/IDbCommandLogFormatter.cs
+++ b/src/Sentry.EntityFramework/IDbCommandLogFormatter.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Common;
+
+namespace Sentry.EntityFramework
+{
+    public interface IDbCommandLogFormatter
+    {
+        /// <summary>
+        /// Gets the message to log from <paramref name="command"/>
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        string GetLogMessage(DbCommand command);
+    }
+}

--- a/src/Sentry.EntityFramework/SentryCommandInterceptor.cs
+++ b/src/Sentry.EntityFramework/SentryCommandInterceptor.cs
@@ -7,8 +7,13 @@ namespace Sentry.EntityFramework
     public class SentryCommandInterceptor : IDbCommandInterceptor
     {
         private readonly IQueryLogger _queryLogger;
+        private readonly IDbCommandLogFormatter _dbCommandLogFormatter;
 
-        public SentryCommandInterceptor(IQueryLogger queryLogger) => _queryLogger = queryLogger;
+        public SentryCommandInterceptor(IQueryLogger queryLogger, IDbCommandLogFormatter dbCommandLogFormatter)
+        {
+            _queryLogger = queryLogger;
+            _dbCommandLogFormatter = dbCommandLogFormatter;
+        }
 
         public void NonQueryExecuting(DbCommand command, DbCommandInterceptionContext<int> interceptionContext)
             => Log(command, interceptionContext);
@@ -29,11 +34,11 @@ namespace Sentry.EntityFramework
         {
             if (interceptionContext.Exception != null)
             {
-                _queryLogger.Log(command.CommandText, BreadcrumbLevel.Error);
+                _queryLogger.Log(_dbCommandLogFormatter.GetLogMessage(command), BreadcrumbLevel.Error);
             }
             else
             {
-                _queryLogger.Log(command.CommandText);
+                _queryLogger.Log(_dbCommandLogFormatter.GetLogMessage(command));
             }
         }
     }

--- a/src/Sentry.EntityFramework/SentryDatabaseLogging.cs
+++ b/src/Sentry.EntityFramework/SentryDatabaseLogging.cs
@@ -12,10 +12,12 @@ namespace Sentry.EntityFramework
         /// This is a static setup call, so make sure you only call it once for each <see cref="IQueryLogger"/> instance you want to register globally
         /// </summary>
         /// <param name="logger"></param>
-        public static SentryCommandInterceptor UseBreadcrumbs(IQueryLogger logger = null)
+        /// <param name="dbCommandLogFormatter"></param>
+        public static SentryCommandInterceptor UseBreadcrumbs(IQueryLogger logger = null, IDbCommandLogFormatter dbCommandLogFormatter = null)
         {
             logger = logger ?? new SentryQueryLogger();
-            var interceptor = new SentryCommandInterceptor(logger);
+            dbCommandLogFormatter = dbCommandLogFormatter ?? new DbCommandLogFormatter();
+            var interceptor = new SentryCommandInterceptor(logger, dbCommandLogFormatter);
             DbInterception.Add(interceptor);
             return interceptor;
         }


### PR DESCRIPTION
This feature will allow changes in the message to report to Sentry

With this small change it is possible to modify the information from DbCommand to log, for example you can create an implementation of IDbCommandLogFormatter to log command text and parameters information (name, value, type, etc.)

SentryDatabaseLogging.UseBreadcrumbs(dbCommandLogFormatter: new CustomDbCommandLogFormatter());
