### PR TITLE
Updated Sentry version to 2.1.6

### DIFF
--- a/samples/Sentry.Samples.AspNet.Mvc/Sentry.Samples.AspNet.Mvc.csproj
+++ b/samples/Sentry.Samples.AspNet.Mvc/Sentry.Samples.AspNet.Mvc.csproj
@@ -50,14 +50,14 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry, Version=1.1.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.1.1.0\lib\net461\Sentry.dll</HintPath>
+    <Reference Include="Sentry, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sentry.2.1.6\lib\net461\Sentry.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.PlatformAbstractions.1.0.0\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Sentry.PlatformAbstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sentry.PlatformAbstractions.1.1.1\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.Protocol, Version=1.0.2.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.Protocol.1.0.2\lib\net46\Sentry.Protocol.dll</HintPath>
+    <Reference Include="Sentry.Protocol, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sentry.Protocol.2.1.6\lib\net46\Sentry.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/samples/Sentry.Samples.AspNet.Mvc/packages.config
+++ b/samples/Sentry.Samples.AspNet.Mvc/packages.config
@@ -29,9 +29,9 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
-  <package id="Sentry" version="0.0.1-preview4" targetFramework="net462" />
-  <package id="Sentry.PlatformAbstractions" version="1.0.0-preview2" targetFramework="net462" />
-  <package id="Sentry.Protocol" version="0.0.1-preview4" targetFramework="net462" />
+  <package id="Sentry" version="2.1.6" targetFramework="net461" />
+  <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net461" />
+  <package id="Sentry.Protocol" version="2.1.6" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net462" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />

--- a/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
+++ b/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.0.0" />
-    <PackageReference Include="Sentry" Version="1.1.0" />
+    <PackageReference Include="Sentry" Version="2.1.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When using the latest Sentry NuGet (2.1.6) along with current version of Sentry.EntityFramework it seems to be leading to an assembly reference error looking for sentry.protocol 1.0.2. So, this just updates the project to work off the latest version of Sentry preventing that error for anyone in the situation above.