### PR TITLE
Update: bump sentry sdk to 3.0.3

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -64,5 +64,5 @@ if ($lastexitcode -ne 0) { Write-Error "Build failed!" }
 if ($lastexitcode -ne 0) { Write-Error "Pack failed!" }
 
 Set-Variable -name runner -value (GetTestRunner)
-& $runner  "test\Sentry.EntityFramework.Tests\bin\Release\net462\Sentry.EntityFramework.Tests.dll"
+& $runner  "test\Sentry.EntityFramework.Tests\bin\Release\net461\Sentry.EntityFramework.Tests.dll"
 if ($lastexitcode -ne 0) { Set-Variable -name fail -value true }

--- a/samples/Sentry.Samples.AspNet.Mvc/Global.asax.cs
+++ b/samples/Sentry.Samples.AspNet.Mvc/Global.asax.cs
@@ -25,7 +25,7 @@ namespace Sentry.Samples.AspNet.Mvc
             _sentrySdk = SentrySdk.Init(o =>
             {
                 // We store the DSN inside Web.config; make sure to use your own DSN!
-                o.Dsn = new Dsn(ConfigurationManager.AppSettings["SentryDsn"]);
+                o.Dsn = ConfigurationManager.AppSettings["SentryDsn"];
          
                 // Add the EntityFramework integration
                 o.AddEntityFramework();

--- a/samples/Sentry.Samples.AspNet.Mvc/Sentry.Samples.AspNet.Mvc.csproj
+++ b/samples/Sentry.Samples.AspNet.Mvc/Sentry.Samples.AspNet.Mvc.csproj
@@ -46,29 +46,51 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.2.1.6\lib\net461\Sentry.dll</HintPath>
-    </Reference>
-    <Reference Include="Sentry.PlatformAbstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.PlatformAbstractions.1.1.1\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Sentry.Protocol, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sentry.Protocol.2.1.6\lib\net46\Sentry.Protocol.dll</HintPath>
+    <Reference Include="Sentry, Version=3.0.3.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sentry.3.0.3\lib\net461\Sentry.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.5.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Json.5.0.0\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/samples/Sentry.Samples.AspNet.Mvc/Web.config
+++ b/samples/Sentry.Samples.AspNet.Mvc/Web.config
@@ -93,6 +93,10 @@
         <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/samples/Sentry.Samples.AspNet.Mvc/Web.config
+++ b/samples/Sentry.Samples.AspNet.Mvc/Web.config
@@ -17,7 +17,7 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <!-- Sentry DSN, replace this with your own -->
-    <add key="SentryDsn" value="https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141" />
+    <add key="SentryDsn" value="https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -91,7 +91,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/samples/Sentry.Samples.AspNet.Mvc/packages.config
+++ b/samples/Sentry.Samples.AspNet.Mvc/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net462" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.4" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.6.1" targetFramework="net462" developmentDependency="true" />
@@ -29,12 +30,18 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
-  <package id="Sentry" version="2.1.6" targetFramework="net461" />
-  <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net461" />
-  <package id="Sentry.Protocol" version="2.1.6" targetFramework="net461" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
+  <package id="Sentry" version="3.0.3" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="5.0.0" targetFramework="net461" />
+  <package id="System.Text.Json" version="5.0.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/src/Sentry.EntityFramework/IQueryLogger.cs
+++ b/src/Sentry.EntityFramework/IQueryLogger.cs
@@ -1,5 +1,3 @@
-using Sentry.Protocol;
-
 namespace Sentry.EntityFramework
 {
     public interface IQueryLogger

--- a/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
+++ b/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
@@ -29,11 +29,11 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.0.0" />
-    <PackageReference Include="Sentry" Version="2.1.6" />
+    <PackageReference Include="Sentry" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
+    <None Include="../../.assets/sentry-nuget.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry.EntityFramework/SentryCommandInterceptor.cs
+++ b/src/Sentry.EntityFramework/SentryCommandInterceptor.cs
@@ -1,6 +1,5 @@
 using System.Data.Common;
 using System.Data.Entity.Infrastructure.Interception;
-using Sentry.Protocol;
 
 namespace Sentry.EntityFramework
 {

--- a/src/Sentry.EntityFramework/SentryQueryLogger.cs
+++ b/src/Sentry.EntityFramework/SentryQueryLogger.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.EntityFramework
 {

--- a/test/Sentry.EntityFramework.Tests/DsnSamples.cs
+++ b/test/Sentry.EntityFramework.Tests/DsnSamples.cs
@@ -19,6 +19,6 @@ namespace Sentry
         /// <summary>
         /// Valid DSN instance
         /// </summary>
-        public static Dsn Valid = new Dsn(ValidDsnWithSecret);
+        public static string Valid => ValidDsnWithSecret;
     }
 }

--- a/test/Sentry.EntityFramework.Tests/ErrorProcessorTests.cs
+++ b/test/Sentry.EntityFramework.Tests/ErrorProcessorTests.cs
@@ -4,13 +4,8 @@ using System.Data;
 using System.Data.Common;
 using System.Data.Entity.Validation;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using NSubstitute;
 using Sentry.EntityFramework.ErrorProcessors;
-using Sentry.Extensibility;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.EntityFramework.Tests

--- a/test/Sentry.EntityFramework.Tests/SentryCommandInterceptorTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryCommandInterceptorTests.cs
@@ -4,7 +4,6 @@ using System.Data.Entity.Infrastructure.Interception;
 using System.Linq;
 using Effort.Provider;
 using NSubstitute;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.EntityFramework.Tests

--- a/test/Sentry.EntityFramework.Tests/SentryQueryLoggerTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryQueryLoggerTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NSubstitute;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.EntityFramework.Tests


### PR DESCRIPTION
Closes #10.

Sample errors captured:
https://sentry.io/share/issue/8f99f27273a641c692a3d269881c55c3/

https://sentry.io/share/issue/4e28dca2bc254e93a4ffc4285e7fec1d/

* I'm not an expert with Dotnet ef, but the tests are passing and the sample running :D 

* About the tests, it seems the script was hardcoded to test the net462 output while the test was targeting net461, by that, no tests were running (at least on my machine).

* System.Runtime.InteropServices.RuntimeInformation on the Sample project was targeting the wrong version, thus generating an error when loading the project.

Breaking changes:
 Sentry.Protocol and Sentry.PlatformAbstractions are no longer required and the DSN is just a string.